### PR TITLE
fix: AllowUserOverrides to be bool

### DIFF
--- a/macOS UAMDM - Kext Policy Example (Santa).mobileconfig
+++ b/macOS UAMDM - Kext Policy Example (Santa).mobileconfig
@@ -6,7 +6,7 @@
 	<array>
 		<dict>
 			<key>AllowUserOverrides</key>
-			<integer>1</integer>
+			<true/>
 			<key>AllowedKernelExtensions</key>
 			<dict>
 				<key>EQHXZ8M8AV</key>

--- a/macOS UAMDM - Kext Policy Example.mobileconfig
+++ b/macOS UAMDM - Kext Policy Example.mobileconfig
@@ -6,7 +6,7 @@
 	<array>
 		<dict>
 			<key>AllowUserOverrides</key>
-			<integer>0</integer>
+			<false/>
 			<key>AllowedKernelExtensions</key>
 			<dict>
 				<key>EQHXZ8M8AV</key>


### PR DESCRIPTION
These aren't integer values. Best I've got for documentation is http://www.openradar.me/35307623#ag9zfm9wZW5yYWRhci1ocmRyFAsSB0NvbW1lbnQYgICA2NL65ggM

I'm sure Apple has this documented someplace...